### PR TITLE
refactor(models): reorganize models directory and fix exercise repr.

### DIFF
--- a/styx/models/__init__.py
+++ b/styx/models/__init__.py
@@ -1,34 +1,13 @@
-from datetime import datetime
-from uuid import UUID, uuid4
+from styx.models.base import BaseModel
+from styx.models.core import (
+           Exercise,
+           ExerciseType,
+           MuscleGroup,
+           SetType,
+)
+from styx.models.planned import PlannedSet
+from styx.models.user import User
 
-from sqlalchemy import DateTime, func
-from sqlalchemy.orm import Mapped, mapped_column
-
-from ..extensions import db
-
-
-class BaseModel(db.Model): # type: ignore
-    """Base model class that can be used by all models."""
-
-    __abstract__ = True
-    # Common columns that should be in all models
-    
-    # Use UUID instead of sequential ids for security issues that may arise
-    # read more here: https://www.pingcap.com/article/the-benefits-of-using-uuids-for-unique-identification/.
-    id: Mapped[UUID] = mapped_column(
-        primary_key=True,
-        default=uuid4,  # Auto-generate UUIDs for new records.
-    )
-
-    created_on: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),  # generates the current
-                                    # timestamp on insert.
-    )
-
-    updated_on: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),  # generates the current 
-                                    # timestamp on insert.
-        onupdate=func.now(),  # updated on row update.
-    )
+__all__ = ["BaseModel", "User", "Exercise", 
+           "ExerciseType", "MuscleGroup", "SetType",
+           "PlannedSet"]

--- a/styx/models/base.py
+++ b/styx/models/base.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from styx.extensions import db
+
+
+class BaseModel(db.Model): # type: ignore
+    """Base model class that can be used by all models."""
+
+    __abstract__ = True
+    # Common columns that should be in all models
+    
+    # Use UUID instead of sequential ids for security issues that may arise
+    # read more here: https://www.pingcap.com/article/the-benefits-of-using-uuids-for-unique-identification/.
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True,
+        default=uuid4,  # Auto-generate UUIDs for new records.
+    )
+
+    created_on: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),  # generates the current
+                                    # timestamp on insert.
+    )
+
+    updated_on: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),  # generates the current 
+                                    # timestamp on insert.
+        onupdate=func.now(),  # updated on row update.
+    )

--- a/styx/models/core/__init__.py
+++ b/styx/models/core/__init__.py
@@ -1,0 +1,6 @@
+from .exercise import Exercise
+from .exercise_type import ExerciseType
+from .muscle_group import MuscleGroup
+from .set_type import SetType
+
+__all__ = ["Exercise", "ExerciseType", "MuscleGroup", "SetType"]

--- a/styx/models/core/exercise.py
+++ b/styx/models/core/exercise.py
@@ -35,8 +35,6 @@ class Exercise(BaseModel):
 
 
     def __repr__(self) -> str:
-        return f"Exercise( \
-                            name={self.name}, \
-                            types={self.exercise_types}, \
-                            muscle_groups={self.muscle_groups} \
-                         )"
+        return (f"Exercise(name={self.name}, "
+                f"types={self.exercise_types}, "
+                f"muscle_groups={self.muscle_groups})")

--- a/styx/models/core/exercise.py
+++ b/styx/models/core/exercise.py
@@ -1,13 +1,17 @@
-from sqlalchemy import List, String
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from . import BaseModel
-from .exercise_type_model import ExerciseType
-from .muscle_group_model import MuscleGroup
-from .relationships import (
+from ..base import BaseModel
+from ..relationships import (
     exercise_type_association_table,
     muscle_group_association_table,
 )
+
+if TYPE_CHECKING:
+    from .exercise_type import ExerciseType
+    from .muscle_group import MuscleGroup
 
 
 class Exercise(BaseModel): 
@@ -16,14 +20,14 @@ class Exercise(BaseModel):
     name: Mapped[str] = mapped_column(String(120), unique=True)
 
     # many to many relationship with Exercise Type table
-    exercise_types: Mapped[List["ExerciseType"]] = relationship(
+    exercise_types: Mapped[list["ExerciseType"]] = relationship(
         "ExerciseType",
         secondary=exercise_type_association_table,
         back_populates="exercises",
     )
 
     # many to many relationship with Muscle Group table
-    muscle_groups: Mapped[List["MuscleGroup"]] = relationship(
+    muscle_groups: Mapped[list["MuscleGroup"]] = relationship(
         "MuscleGroup",
         secondary=muscle_group_association_table,
         back_populates="exercises",

--- a/styx/models/core/exercise_type.py
+++ b/styx/models/core/exercise_type.py
@@ -1,9 +1,13 @@
-from sqlalchemy import List, Optional, String
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from . import BaseModel
-from .exercise_model import Exercise
-from .relationships import exercise_type_association_table
+from ..base import BaseModel
+from ..relationships import exercise_type_association_table
+
+if TYPE_CHECKING:
+    from .exercise import Exercise
 
 
 class ExerciseType(BaseModel):
@@ -12,7 +16,7 @@ class ExerciseType(BaseModel):
     name: Mapped[str] = mapped_column(String(120), unique=True)
 
     # many to many field with Exercise table
-    exercises: Mapped[Optional[List[Exercise]]] = relationship(
+    exercises: Mapped[list["Exercise"] | None] = relationship(
         "Exercise",
         secondary=exercise_type_association_table,
         back_populates="exercise_types",
@@ -22,4 +26,3 @@ class ExerciseType(BaseModel):
 
     def __repr__(self) -> str:
         return f"ExerciseType(name={self.name})"
-    

--- a/styx/models/core/muscle_group.py
+++ b/styx/models/core/muscle_group.py
@@ -1,9 +1,14 @@
-from sqlalchemy import List, Optional, String
+from typing import TYPE_CHECKING
+
+from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from . import BaseModel
-from .exercise_model import Exercise
-from .relationships import muscle_group_association_table
+from ..base import BaseModel
+from ..relationships import muscle_group_association_table
+from .exercise import Exercise
+
+if TYPE_CHECKING:
+    from .exercise import Exercise
 
 
 class MuscleGroup(BaseModel):
@@ -12,7 +17,7 @@ class MuscleGroup(BaseModel):
     name: Mapped[str] = mapped_column(String(120), unique=True)
 
     # many to many field with Exercise table
-    exercises: Mapped[Optional[List[Exercise]]] = relationship(
+    exercises: Mapped[list["Exercise"] | None] = relationship(
         "Exercise",
         secondary=muscle_group_association_table,
         back_populates="muscle_groups",

--- a/styx/models/core/set_type.py
+++ b/styx/models/core/set_type.py
@@ -1,7 +1,7 @@
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from . import BaseModel
+from ..base import BaseModel
 
 
 class SetType(BaseModel):

--- a/styx/models/planned/__init__.py
+++ b/styx/models/planned/__init__.py
@@ -1,0 +1,3 @@
+from .planned_set import PlannedSet
+
+__all__ = ["PlannedSet"]

--- a/styx/models/planned/planned_set.py
+++ b/styx/models/planned/planned_set.py
@@ -8,8 +8,9 @@ from sqlalchemy.orm import (
     validates,
 )
 
-from . import BaseModel
-from .set_type_model import SetType
+from styx.models.core.set_type import SetType
+
+from ..base import BaseModel
 
 
 class PlannedSet(BaseModel):

--- a/styx/models/relationships.py
+++ b/styx/models/relationships.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, ForeignKey, Table
 
-from . import BaseModel
+from .base import BaseModel
 
 # Association Table for many to many relationship
 # between Exercise and Exercise type

--- a/styx/models/user/__init__.py
+++ b/styx/models/user/__init__.py
@@ -1,0 +1,3 @@
+from .user import User
+
+__all__ = ["User"]

--- a/styx/models/user/user.py
+++ b/styx/models/user/user.py
@@ -2,8 +2,8 @@ from sqlalchemy import String
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ..extensions import bcrypt
-from . import BaseModel
+from styx.extensions import bcrypt
+from styx.models.base import BaseModel
 
 
 class User(BaseModel): #type: ignore

--- a/tests/test_planned_set_model.py
+++ b/tests/test_planned_set_model.py
@@ -1,8 +1,7 @@
 import pytest
 
 from styx import db
-from styx.models.planned_set_model import PlannedSet
-from styx.models.set_type_model import SetType
+from styx.models import PlannedSet, SetType
 
 
 @pytest.fixture

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -16,7 +16,7 @@ import time
 import pytest
 
 from styx import db
-from styx.models.user_model import User
+from styx.models import User
 
 
 @pytest.fixture


### PR DESCRIPTION
- Split models package into domain-specific sub-packages:
  1. core: Exercise, ExerciseType, MuscleGroup, SetType (*more to be added later*)
  2. planned: PlannedSet (*more to be added later*)
  3. performed: Stub implementation (*future expansion*)
  4. user: User model (*auth features to be added later*)

- Move Base model class from package `__init__` to `base.py`.
- Add explicit exports in subpackage `__init__` files.
- Update test imports to reflect new structure.
- Fix Exercise `__repr__` string.